### PR TITLE
ダークモードでの入力フォームのデザイン修正

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -10,7 +10,7 @@
       <% if @minimum_password_length %>
         <em>(<%= @minimum_password_length %> <%= t('.minimum_password_length') %>)</em>
       <% end %>
-      <label class="input input-bordered flex items-center gap-2">
+      <label class="input input-bordered flex items-center gap-2 bg-white">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 16 16"
@@ -27,7 +27,7 @@
 
     <div class="pt-10 sm:mx-32">
       <%= f.label :password_confirmation, t('.confirm_new_password') %>
-      <label class="input input-bordered flex items-center gap-2">
+      <label class="input input-bordered flex items-center gap-2 bg-white">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 16 16"

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -6,7 +6,7 @@
 
     <div class="pt-10 sm:mx-32">
       <%= f.label :name %>
-      <label class="input input-bordered flex items-center gap-2">
+      <label class="input input-bordered flex items-center gap-2 bg-white">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 16 16"
@@ -21,7 +21,7 @@
 
     <div class="pt-10 sm:mx-32">
       <%= f.label :email %>
-      <label class="input input-bordered flex items-center gap-2">
+      <label class="input input-bordered flex items-center gap-2 bg-white">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 16 16"
@@ -41,7 +41,7 @@
         <% if @minimum_password_length %>
         <em>(<%= @minimum_password_length %><%= t('.minimum_password_length') %>)</em>
       <% end %>
-      <label class="input input-bordered flex items-center gap-2">
+      <label class="input input-bordered flex items-center gap-2 bg-white">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 16 16"
@@ -58,7 +58,7 @@
 
     <div class="pt-10 sm:mx-32">
       <%= f.label :password_confirmation %>
-      <label class="input input-bordered flex items-center gap-2">
+      <label class="input input-bordered flex items-center gap-2 bg-white">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 16 16"

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -4,7 +4,7 @@
 <%= form_with model: @user, url: user_session_path, local: true do |f| %>
   <div class="pt-10 sm:mx-32">
     <%= f.label :email %>
-    <label class="input input-bordered flex items-center gap-2">
+    <label class="input input-bordered flex items-center gap-2 bg-white">
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 16 16"
@@ -24,7 +24,7 @@
       <% if @minimum_password_length %>
       <em>(<%= @minimum_password_length %> characters minimum)</em>
     <% end %>
-    <label class="input input-bordered flex items-center gap-2">
+    <label class="input input-bordered flex items-center gap-2 bg-white">
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 16 16"

--- a/app/views/plans/_edit_form.html.erb
+++ b/app/views/plans/_edit_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: @plan do |f| %>
   <div class='pt-10 sm:mx-32'>
     <%= f.label :title %>
-    <label class='input flex items-center gap-2'>
+    <label class='input flex items-center gap-2 bg-white'>
       <%= f.text_field :title, class: 'w-full', placeholder: t('.title_placeholder') %>
     </label>
   </div>
@@ -9,7 +9,7 @@
   <div class='pt-10 sm:mx-32'>
     <%= f.label :thumbnail %>
     <div class='flex'>
-      <%= f.file_field :thumbnail, direct_upload: true, class: 'w-full file-input border-none custom-file-input' %>
+      <%= f.file_field :thumbnail, direct_upload: true, class: 'w-full file-input border-none custom-file-input bg-white' %>
     </div>
   </div>
   <div class='sm:mx-32'>
@@ -24,7 +24,7 @@
   <div class='pt-10 mb-10 sm:mx-32'>
     <%= f.label :body %>
     <label class='flex w-full'>
-      <%= f.text_area :body, class:'textarea h-24 w-full resize-none text-base', placeholder: t('.body_placeholder') %>
+      <%= f.text_area :body, class:'textarea h-24 w-full resize-none text-base bg-white', placeholder: t('.body_placeholder') %>
     </label>
   </div>
 

--- a/app/views/plans/_edit_spot_fields.html.erb
+++ b/app/views/plans/_edit_spot_fields.html.erb
@@ -1,6 +1,6 @@
 <div class='pt-10 sm:mx-32'>
   <%= f.label :store_name %>
-  <label class='input flex items-center gap-2'>
+  <label class='input flex items-center gap-2 bg-white'>
     <%= f.text_field :store_name, id: 'store', class:'w-full', placeholder: t('.store_name_placeholder') %>
   </label>
 </div>
@@ -8,20 +8,20 @@
 <div class='pt-10 sm:mx-32'>
   <%= f.label :introduction %>
   <label class='flex'>
-  <%= f.text_area :introduction, class:'textarea h-24 w-full resize-none text-base', placeholder: t('.introduction_placeholder') %>
+  <%= f.text_area :introduction, class:'textarea h-24 w-full resize-none text-base bg-white', placeholder: t('.introduction_placeholder') %>
   </label>
 </div>
 
 <div class='pt-10 sm:mx-32' style='display: none;'>
   <%= f.label :address %>
-  <label class='input flex items-center gap-2'>
+  <label class='input flex items-center gap-2 bg-white'>
     <%= f.text_field :address, id: 'address' %>
   </label>
 </div>
 
 <div class='pt-10 sm:mx-32' style='display: none;'>
   <%= f.label :site_url %>
-  <label class='input  flex items-center gap-2'>
+  <label class='input  flex items-center gap-2 bg-white'>
     <%= f.url_field :site_url, id: 'url' %>
   </label>
 </div>
@@ -29,7 +29,7 @@
 <div class='pt-10 mb-5 sm:mx-32'>
   <%= f.label :image %>
   <div class='flex'>
-    <%= f.file_field :image, class: 'w-full, file-input border-none custom-file-input' %>
+    <%= f.file_field :image, class: 'w-full, file-input border-none custom-file-input bg-white' %>
   </div>
   <div class='sm:mx-32'>
     <% if f.object.image&.attached? %>

--- a/app/views/plans/_form.html.erb
+++ b/app/views/plans/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: @plan do |f| %>
   <div class='pt-10 sm:mx-32'>
     <%= f.label :title %>
-    <label class='input flex items-center gap-2'>
+    <label class='input flex items-center gap-2 bg-white'>
       <%= f.text_field :title, class: 'w-full', placeholder: t('.title_placeholder') %>
     </label>
   </div>
@@ -9,7 +9,7 @@
   <div class='pt-10 mb-10 sm:mx-32'>
     <%= f.label :body %>
     <label class='flex w-full'>
-      <%= f.text_area :body, class:'textarea h-24 w-full resize-none text-base', placeholder: t('.body_placeholder') %>
+      <%= f.text_area :body, class:'textarea h-24 w-full resize-none text-base bg-white', placeholder: t('.body_placeholder') %>
     </label>
   </div>
 

--- a/app/views/plans/_plan.html.erb
+++ b/app/views/plans/_plan.html.erb
@@ -1,52 +1,52 @@
 <div class='mb-5 mx-5'>
-  <div class='card lg:flex-row lg:card-side bg-base-100 shadow-xl md:w-84 lg:w-96 mx-auto'>
-  <div class='flex flex-col'>
-    <div class='my-3 mx-3 flex-shrink-0'>
-      <%= link_to plan_path(plan) do %>
-        <div class='flex'>
-          <% if plan.thumbnail.present? %>
-            <%= image_tag plan.thumbnail, class: 'w-32 h-32 object-cover rounded-lg' %>
-          <% else %>
-            <%= image_tag('sample.jpeg', class: 'w-32 h-32 rounded-lg') %>
-          <% end %>
-          <div class='flex flex-col justify-between w-full h-32 ml-5 md:w-42 lg:w-48 mx-auto'>
-            <h2 class='text-main-orange font-bold'><%= truncate(plan.title, length: 20) %></h2>
-            <div  class='text-right text-xs mb-3'>
-              <span class='border-b border-gray-600'><%= t('.see_in_detail') %></span>
+  <div class='card lg:flex-row lg:card-side bg-white shadow-xl md:w-84 lg:w-96 mx-auto'>
+    <div class='flex flex-col'>
+      <div class='my-3 mx-3 flex-shrink-0'>
+        <%= link_to plan_path(plan) do %>
+          <div class='flex'>
+            <% if plan.thumbnail.present? %>
+              <%= image_tag plan.thumbnail, class: 'w-32 h-32 object-cover rounded-lg' %>
+            <% else %>
+              <%= image_tag('sample.jpeg', class: 'w-32 h-32 rounded-lg') %>
+            <% end %>
+            <div class='flex flex-col justify-between w-full h-32 ml-5 md:w-42 lg:w-48 mx-auto'>
+              <h2 class='text-main-orange font-bold'><%= truncate(plan.title, length: 20) %></h2>
+              <div  class='text-right text-xs mb-3'>
+                <span class='border-b border-gray-600'><%= t('.see_in_detail') %></span>
+              </div>
             </div>
           </div>
-        </div>
-      <% end %>
-    </div>
-    <div  class='flex justify-between mb-3 mx-3 flex-grow'>
-      <div class='flex'>
-        <div>
-          <i class='fa-solid fa-location-dot fa-lg' style='color: #ffb83d;'></i>
-          <span class='text-xs'><%= plan.first_spot_address %></span>
-        </div>
-        <div class='flex ml-2'>
-          <% if plan.user.profile_image&.avatar&.attached? %>
-            <%= image_tag(plan.user.profile_image.avatar, class: 'w-7 h-7 rounded-full') %>
-          <% else %>
-            <%= image_tag('sample.jpeg', class: 'w-7 h-7 rounded-full') %>
-          <% end %>
-          <span class='pl-1 text-xs leading-7'><%= truncate(plan.user.name, length: 6) %></span>
-        </div>
+        <% end %>
       </div>
-      <% if user_signed_in? && current_user.own?(plan) %>
-        <div>
-          <%= link_to "https://twitter.com/share?url=#{ plan_url(plan) }&text=【おすすめの旅スポットを投稿しました！！】%0a%0a#{ plan.title }", target: '_blank' do %>
-            <i class='fa-brands fa-square-x-twitter fa-lg'></i>
-          <% end %>
-          <%= link_to edit_plan_path(plan) do %>
-            <i class='fa-solid fa-pen-to-square fa-lg ml-5' style='color: #3d98ff;'></i>
-          <% end %>
-          <%= link_to plan_path(plan), data: { turbo_method: :delete, turbo_confirm: t('.deleting_confirmation') } do %>
-            <i class='fa-solid fa-trash-can fa-lg ml-5' style='color: #ed7b7b;'></i>
-          <% end %>
+      <div  class='flex justify-between mb-3 mx-3 flex-grow'>
+        <div class='flex'>
+          <div>
+            <i class='fa-solid fa-location-dot fa-lg' style='color: #ffb83d;'></i>
+            <span class='text-xs'><%= plan.first_spot_address %></span>
+          </div>
+          <div class='flex ml-2'>
+            <% if plan.user.profile_image&.avatar&.attached? %>
+              <%= image_tag(plan.user.profile_image.avatar, class: 'w-7 h-7 rounded-full') %>
+            <% else %>
+              <%= image_tag('sample.jpeg', class: 'w-7 h-7 rounded-full') %>
+            <% end %>
+            <span class='pl-1 text-xs leading-7'><%= truncate(plan.user.name, length: 6) %></span>
+          </div>
         </div>
-      <% end %>
+        <% if user_signed_in? && current_user.own?(plan) %>
+          <div>
+            <%= link_to "https://twitter.com/share?url=#{ plan_url(plan) }&text=【おすすめの旅スポットを投稿しました！！】%0a%0a#{ plan.title }", target: '_blank' do %>
+              <i class='fa-brands fa-square-x-twitter fa-lg'></i>
+            <% end %>
+            <%= link_to edit_plan_path(plan) do %>
+              <i class='fa-solid fa-pen-to-square fa-lg ml-5' style='color: #3d98ff;'></i>
+            <% end %>
+            <%= link_to plan_path(plan), data: { turbo_method: :delete, turbo_confirm: t('.deleting_confirmation') } do %>
+              <i class='fa-solid fa-trash-can fa-lg ml-5' style='color: #ed7b7b;'></i>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
     </div>
-  </div>
   </div>
 </div>

--- a/app/views/plans/_spot_fields.html.erb
+++ b/app/views/plans/_spot_fields.html.erb
@@ -2,7 +2,7 @@
   <%= f.hidden_field :_destroy %>
   <div class='pt-10 sm:mx-32'>
     <%= f.label :store_name %>
-    <label class='input flex items-center gap-2'>
+    <label class='input flex items-center gap-2 bg-white'>
       <%= f.text_field :store_name, id: 'store', class:'w-full', placeholder: t('.store_name_placeholder'), autocomplete: 'off' %>
     </label>
   </div>
@@ -10,20 +10,20 @@
   <div class='pt-10 sm:mx-32'>
     <%= f.label :introduction %>
     <label class='flex'>
-    <%= f.text_area :introduction, class:'textarea h-24 w-full resize-none text-base', placeholder: t('.introduction_placeholder') %>
+    <%= f.text_area :introduction, class:'textarea h-24 w-full resize-none text-base bg-white', placeholder: t('.introduction_placeholder') %>
     </label>
   </div>
 
   <div class='pt-10 sm:mx-32' style='display: none;'>
     <%= f.label :address %>
-    <label class='input flex items-center gap-2'>
+    <label class='input flex items-center gap-2 bg-white'>
       <%= f.text_field :address, id: 'address' %>
     </label>
   </div>
 
   <div class='pt-10 sm:mx-32' style='display: none;'>
     <%= f.label :site_url %>
-    <label class='input  flex items-center gap-2'>
+    <label class='input  flex items-center gap-2 bg-white'>
       <%= f.url_field :site_url, id: 'url' %>
     </label>
   </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -6,7 +6,7 @@
       <%= f.fields_for :profile_image do |profile_image_form| %>
   <%= profile_image_form.label :avatar %>
   <div class='flex'>
-    <%= profile_image_form.file_field :avatar, direct_upload: true, class: 'w-full file-input border-none custom-file-input' %>
+    <%= profile_image_form.file_field :avatar, direct_upload: true, class: 'w-full file-input border-none custom-file-input bg-white' %>
   </div>
 <% end %>
     </div>
@@ -21,7 +21,7 @@
 
     <div class="pt-10 sm:mx-32">
       <%= f.label :name %>
-      <label class="input flex items-center gap-2">
+      <label class="input flex items-center gap-2 bg-white">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 16 16"

--- a/app/views/profiles/email_edit.html.erb
+++ b/app/views/profiles/email_edit.html.erb
@@ -6,7 +6,7 @@
 
     <div class="pt-10 sm:mx-32">
       <%= f.label :email %>
-      <label class="input flex items-center gap-2">
+      <label class="input flex items-center gap-2 bg-white">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 16 16"

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -1,6 +1,6 @@
 <%= search_form_for q, url: url do |f| %>
   <div class="relative flex items-center mt-6 mb-6 sm:mx-32">
-    <%= f.text_field :title_or_body_or_spots_store_name_cont, class:'input input-bordered w-full pr-10', placeholder: t('.search_placeholder') %>
+    <%= f.text_field :title_or_body_or_spots_store_name_cont, class:'input input-bordered w-full pr-10 bg-white', placeholder: t('.search_placeholder') %>
     <button type='submit' class='absolute right-3 bg-transparent border-none cursor-pointer'>
       <i class="fa-solid fa-magnifying-glass"></i>
     </button>


### PR DESCRIPTION
ダークモードでブラウザを使用した際に入力フォームも黒くなり、入力値が見えにくくなる問題を解消した。
調査したところChromeでは発生しておらず、Edgeのダークモードを使用した場合にのみ起こることがわかった。
各入力フォームのCSSに背景を白にする記述をすることで本問題は解決した。