### PR TITLE
プライバシーポリシーとお問い合わせ画面の実装

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,3 +1,7 @@
 class StaticPagesController < ApplicationController
   def usage; end
+
+  def inquiry; end
+
+  def privacy; end
 end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,8 +2,8 @@
   <div class='text-center pt-12 pb-2'>
     <ul class='mb-6'>
       <li class='mb-3' style='display: none;'><a href='#'>利用規約</a></li>
-      <li class='mb-3' style='display: none;'><a href='#'>プライバシーポリシー</a></li>
-      <li class='mb-3' style='display: none;'><a href='#'>お問い合わせ</a></li>
+      <li class='mb-3'><%= link_to 'プライバシーポリシー', privacy_path %></li>
+      <li class='mb-3'><%= link_to 'お問い合わせ', inquiry_path %></li>
     </ul>
     <div class='border-t border-gray-600 mx-12 pt-4'>
       <p><small>&copy;2024 旅つなぎ</small></p>

--- a/app/views/static_pages/inquiry.html.erb
+++ b/app/views/static_pages/inquiry.html.erb
@@ -1,0 +1,3 @@
+<main class='py-0 px-5 my-0 mx-auto max-w-screen-xl h-full z-10'>
+  <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSdkCHsOjRWiDwpvmgiMxR1wjiHRL0MlEW1gmmlxR4xgs5ADNw/viewform?embedded=true" width="100%" height="700" frameborder="0" marginheight="0" marginwidth="0">読み込んでいます…</iframe>
+</main>

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,0 +1,44 @@
+<main class='py-0 px-5 mt-0 mb-20 mx-auto max-w-screen-xl h-full z-10'>
+  <h1 class='text-accent-blue font-bold pt-4 pb-5 mb-5 mx-auto text-center text-xl'><%= t('.title') %></h1>
+  <h2 class='font-bold mt-5 mb-3 text-lg'>お客様から取得する情報</h2>
+  <p>当社は、お客様から以下の情報を取得します。</p>
+  <ul class='list-disc mt-3 mb-5 ml-5'>
+    <li>氏名(ニックネームやペンネームも含む)</li>
+    <li>メールアドレス</li>
+    <li>写真や動画</li>
+    <li>外部サービスでお客様が利用するID、その他外部サービスのプライバシー設定によりお客様が連携先に開示を認めた情報</li>
+    <li>Cookie(クッキー)を用いて生成された識別情報</li>
+    <li>OSが生成するID、端末の種類、端末識別子等のお客様が利用するOSや端末に関する情報</li>
+    <li>当社アプリの起動時間、入力履歴、購買履歴等の当社アプリの利用履歴</li>
+  </ul>
+  <h2 class='font-bold mt-5 mb-3 text-lg'>お客様の情報を利用する目的</h2>
+  <p>当社は、お客様から取得した情報を、以下の目的のために利用します。</p>
+  <ul class='list-disc mt-3 mb-5 ml-5'>
+    <li>当社サービスに関する登録の受付、お客様の本人確認、認証のため</li>
+    <li>お客様の当社サービスの利用履歴を管理するため</li>
+    <li>当社サービスにおけるお客様の行動履歴を分析し、当社サービスの維持改善に役立てるため</li>
+    <li>お客様からのお問い合わせに対応するため</li>
+    <li>当社の規約や法令に違反する行為に対応するため</li>
+    <li>当社サービスの変更、提供中止、終了、契約解除をご連絡するため</li>
+    <li>当社規約の変更等を通知するため</li>
+    <li>以上の他、当社サービスの提供、維持、保護及び改善のため</li>
+  </ul>
+  <h2 class='font-bold mt-5 mb-3 text-lg'>安全管理のために講じた措置</h2>
+  <p>当社が、お客様から取得した情報に関して安全管理のために講じた措置につきましては、末尾記載のお問い合わせ先にご連絡をいただきましたら、法令の定めに従い個別にご回答させていただきます。</p>
+  <h2 class='font-bold mt-5 mb-3 text-lg'>第三者提供</h2>
+  <p>当社は、お客様から取得する情報のうち、個人データ（個人情報保護法第１６条第３項）に該当するものついては、あらかじめお客様の同意を得ずに、第三者（日本国外にある者を含みます。）に提供しません。</p>
+  <p>但し、次の場合は除きます。</p>
+  <ul class='list-disc mt-3 mb-5 ml-5'>
+    <li>個人データの取扱いを外部に委託する場合</li>
+    <li>当社や当社サービスが買収された場合</li>
+    <li>事業パートナーと共同利用する場合（具体的な共同利用がある場合は、その内容を別途公表します。）</li>
+    <li>その他、法律によって合法的に第三者提供が許されている場合</li>
+  </ul>
+  <h2 class='font-bold mt-5 mb-3 text-lg'>アクセス解析ツール</h2>
+  <p>当社は、お客様のアクセス解析のために、「Googleアナリティクス」を利用しています。Googleアナリティクスは、トラフィックデータの収集のためにCookieを使用しています。トラフィックデータは匿名で収集されており、個人を特定するものではありません。Cookieを無効にすれば、これらの情報の収集を拒否することができます。詳しくはお使いのブラウザの設定をご確認ください。Googleアナリティクスについて、詳しくは以下からご確認ください。</p>
+  <a class='text-accent-blue font-bold hover:opacity-75 break-words' href='https://marketingplatform.google.com/about/analytics/terms/jp/'>https://marketingplatform.google.com/about/analytics/terms/jp/</a>
+  <h2 class='font-bold mt-5 mb-3 text-lg'>プライバシーポリシーの変更</h2>
+  <p>当社は、必要に応じて、このプライバシーポリシーの内容を変更します。この場合、変更後のプライバシーポリシーの施行時期と内容を適切な方法により周知または通知します。</p>
+  <h2 class='font-bold mt-5 mb-3 text-lg'>お問い合わせ</h2>
+  <p>お客様の情報の開示、情報の訂正、利用停止、削除をご希望の場合は、<%= link_to 'お問い合わせフォーム', inquiry_path, class:'text-accent-blue font-bold hover:opacity-75' %>よりご連絡ください。</p>
+</main>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -80,6 +80,8 @@ ja:
       post: 投稿する
       account_registration: ログインして投稿する
       List_of_posts: みんなの投稿を見る
+    privacy:
+      title: プライバシーポリシー
   shared:
     before_login_header:
       title: 旅つなぎ

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
 
   get 'edit_last_plan', to: 'plans#edit_last', as: :edit_last_plan
   get 'usage', to: 'static_pages#usage'
+  get 'inquiry', to: 'static_pages#inquiry'
+  get 'privacy', to: 'static_pages#privacy'
 
   resources :plans, only: %i[index new create edit show update destroy] do
     collection do


### PR DESCRIPTION
## チケットへのリンク

http://localhost:3000/privacy
http://localhost:3000/inquiry

## やったこと(issue番号も記述する)

- [ ] #35 
- [ ] #37 

## やらないこと

なし

## できるようになること（ユーザ目線）

お問い合わせ画面とプライバシーポリシー画面にアクセスできるようになった。
お問い合わせ画面ではお問い合わせができる。

## できなくなること（ユーザ目線）

なし

## 動作確認

ブラウザ上で動作確認済み

## その他

なし