### PR TITLE
レイアウト調整

### DIFF
--- a/app/views/plans/_edit_form.html.erb
+++ b/app/views/plans/_edit_form.html.erb
@@ -16,7 +16,7 @@
     <% if plan.thumbnail.present? %>
       <p><%= t('.current_image') %></p>
       <div>
-        <%= image_tag plan.thumbnail, class: 'w-32 h-32 rounded-lg' %>
+        <%= image_tag plan.thumbnail, class: 'w-32 h-32 rounded-lg object-cover' %>
       </div>
     <% end %>
   </div>

--- a/app/views/plans/_edit_spot_fields.html.erb
+++ b/app/views/plans/_edit_spot_fields.html.erb
@@ -35,7 +35,7 @@
     <% if f.object.image&.attached? %>
       <p><%= t('.current_image') %></p>
       <div>
-        <%= image_tag f.object.image, class: 'w-32 h-32 rounded-lg' %>
+        <%= image_tag f.object.image, class: 'w-32 h-32 rounded-lg object-cover' %>
       </div>
     <% end %>
   </div>

--- a/app/views/plans/_plan.html.erb
+++ b/app/views/plans/_plan.html.erb
@@ -5,9 +5,9 @@
         <%= link_to plan_path(plan) do %>
           <div class='flex'>
             <% if plan.thumbnail.present? %>
-              <%= image_tag plan.thumbnail, class: 'w-32 h-32 object-cover rounded-lg' %>
+              <%= image_tag plan.thumbnail, class: 'w-32 h-32 object-cover rounded-lg object-cover' %>
             <% else %>
-              <%= image_tag('sample.jpeg', class: 'w-32 h-32 rounded-lg') %>
+              <%= image_tag('sample.jpeg', class: 'w-32 h-32 rounded-lg object-cover') %>
             <% end %>
             <div class='flex flex-col justify-between w-full h-32 ml-5 md:w-42 lg:w-48 mx-auto'>
               <h2 class='text-main-orange font-bold'><%= truncate(plan.title, length: 20) %></h2>
@@ -18,7 +18,7 @@
           </div>
         <% end %>
       </div>
-      <div  class='flex justify-between mb-3 mx-3 flex-grow'>
+      <div class='flex justify-between mb-3 mx-3 flex-grow'>
         <div class='flex'>
           <div>
             <i class='fa-solid fa-location-dot fa-lg' style='color: #ffb83d;'></i>
@@ -26,9 +26,9 @@
           </div>
           <div class='flex ml-2'>
             <% if plan.user.profile_image&.avatar&.attached? %>
-              <%= image_tag(plan.user.profile_image.avatar, class: 'w-7 h-7 rounded-full') %>
+              <%= image_tag(plan.user.profile_image.avatar, class: 'w-7 h-7 rounded-full object-cover') %>
             <% else %>
-              <%= image_tag('sample.jpeg', class: 'w-7 h-7 rounded-full') %>
+              <%= image_tag('sample.jpeg', class: 'w-7 h-7 rounded-full object-cover') %>
             <% end %>
             <span class='pl-1 text-xs leading-7'><%= truncate(plan.user.name, length: 6) %></span>
           </div>

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -2,7 +2,7 @@
   <%= render 'shared/search', q: @q, url: plans_path %>
   <h1 class='text-accent-blue font-bold pt-4 pb-5 mb-5 mx-auto text-center text-xl'><%= t('.title') %></h1>
   <% if @plans.present? %>
-  <div class="mb-10 md:grid md:grid-cols-2 md:gap-4 lg:grid lg:grid-cols-3">
+  <div class="mb-10 md:grid md:grid-cols-2 md:gap-4">
     <% if @search_plans %>
       <% if @search_plans.present? %>
         <%= render @search_plans %>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -1,25 +1,35 @@
-<main class='py-0 px-5 my-0 mx-auto max-w-screen-xl h-full z-10'>
+<main class='py-0 px-5 mb-0 mx-auto max-w-screen-xl h-full z-10'>
   <%= render 'shared/search', q: @q, url: plans_path %>
   <div class='mb-5 mx-5'>
-    <% if user_signed_in? && current_user.own?(@plan) %>
-      <div class="text-right mb-5">
-        <%= link_to "https://twitter.com/share?url=#{ plan_url(@plan) }&text=【おすすめの旅スポットを投稿しました！！】%0a%0a#{ @plan.title }", target: '_blank' do %>
-          <i class='fa-brands fa-square-x-twitter fa-lg'></i>
-        <% end %>
-        <%= link_to edit_plan_path(@plan) do %>
-          <i class='fa-solid fa-pen-to-square fa-lg ml-5' style='color: #3d98ff;'></i>
-        <% end %>
-        <%= link_to plan_path(@plan), data: { turbo_method: :delete, turbo_confirm: t('.deleting_confirmation') } do %>
-          <i class='fa-solid fa-trash-can fa-lg ml-5' style='color: #ed7b7b;'></i>
-        <% end %>
+    <div class='flex justify-between mt-8 mb-3 flex-grow'>
+      <div class='flex'>
+          <% if @plan.user.profile_image&.avatar&.attached? %>
+            <%= image_tag(@plan.user.profile_image.avatar, class: 'w-8 h-8 rounded-full object-cover') %>
+          <% else %>
+            <%= image_tag('sample.jpeg', class: 'w-8 h-8 rounded-full object-cover') %>
+          <% end %>
+          <span class='pl-1 leading-7'><%= truncate(@plan.user.name, length: 8) %></span>
       </div>
-    <% end %>
+      <% if user_signed_in? && current_user.own?(@plan) %>
+        <div>
+          <%= link_to "https://twitter.com/share?url=#{ plan_url(@plan) }&text=【おすすめの旅スポットを投稿しました！！】%0a%0a#{ @plan.title }", target: '_blank' do %>
+            <i class='fa-brands fa-square-x-twitter fa-lg'></i>
+          <% end %>
+          <%= link_to edit_plan_path(@plan) do %>
+            <i class='fa-solid fa-pen-to-square fa-lg ml-5' style='color: #3d98ff;'></i>
+          <% end %>
+          <%= link_to plan_path(@plan), data: { turbo_method: :delete, turbo_confirm: t('.deleting_confirmation') } do %>
+            <i class='fa-solid fa-trash-can fa-lg ml-5' style='color: #ed7b7b;'></i>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
     <h1 class='text-main-orange font-bold pt-4 pb-5 mb-5 mx-auto text-center text-xl'><%= @plan.title %></h1>
     <div>
       <% if @plan.thumbnail.present? %>
-        <%= image_tag @plan.thumbnail, class: 'w-100 h-50 rounded-lg' %>
+        <%= image_tag @plan.thumbnail, class: 'w-100 h-50 mb:w-1/2 md:h-screen mx-auto rounded-lg object-cover' %>
       <% else %>
-        <%= image_tag('sample.jpeg', class: 'w-100 h-50 rounded-lg') %>
+        <%= image_tag('sample.jpeg', class: 'w-100 h-50 rounded-lg object-cover') %>
       <% end %>
     </div>
     <p class='pt-4 pb-5 mb-5 mx-auto'><%= @plan.body %></p>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -14,7 +14,7 @@
       <% if current_user.profile_image&.avatar&.attached? %>
         <p>現在の画像</p>
         <div>
-          <%= image_tag current_user.profile_image.avatar, class: 'w-32 h-32 rounded-lg' %>
+          <%= image_tag current_user.profile_image.avatar, class: 'w-32 h-32 rounded-lg object-cover' %>
         </div>
       <% end %>
     </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -3,9 +3,9 @@
   <div class='text-center'>
     <div>
       <% if current_user.profile_image&.avatar&.attached? %>
-        <%= image_tag(current_user.profile_image.avatar, class: 'my-0 mx-auto w-32 h-32 rounded-full') %>
+        <%= image_tag(current_user.profile_image.avatar, class: 'my-0 mx-auto w-32 h-32 rounded-full object-cover') %>
       <% else %>
-        <%= image_tag('sample.jpeg', class: 'my-0 mx-auto w-32 h-32 rounded-full') %>
+        <%= image_tag('sample.jpeg', class: 'my-0 mx-auto w-32 h-32 rounded-full object-cover') %>
       <% end %>
       <span class='pl-1'><%= current_user.name %></span>
     </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,9 +7,9 @@
       <%= link_to profile_path, class: 'mr-12' do %>
         <div class='cursor-pointer sm:hidden'>
           <% if current_user.profile_image&.avatar&.attached? %>
-            <%= image_tag(current_user.profile_image.avatar, class: 'w-7 h-7 rounded-full') %>
+            <%= image_tag(current_user.profile_image.avatar, class: 'w-7 h-7 rounded-full object-cover') %>
           <% else %>
-            <%= image_tag('sample.jpeg', class: 'w-7 h-7 rounded-full') %>
+            <%= image_tag('sample.jpeg', class: 'w-7 h-7 rounded-full object-cover') %>
           <% end %>
         </div>
       <% end %>
@@ -32,9 +32,9 @@
           <%= link_to profile_path do %>
             <div class='flex'>
               <% if current_user.profile_image&.avatar&.attached? %>
-                <%= image_tag current_user.profile_image.avatar, class: 'my-0 mx-auto w-8 h-8 rounded-full' %>
+                <%= image_tag current_user.profile_image.avatar, class: 'my-0 mx-auto w-8 h-8 rounded-full object-cover' %>
               <% else %>
-                <%= image_tag('sample.jpeg', class: 'my-0 mx-auto w-8 h-8 rounded-full') %>
+                <%= image_tag('sample.jpeg', class: 'my-0 mx-auto w-8 h-8 rounded-full object-cover') %>
               <% end %>
               <span class='pl-1'><%= current_user.name %></span>
             </div>
@@ -54,9 +54,9 @@
           <li class='mt-6 translate-y-4 transition-opacity transition-transform animate-tracking-in-expand-fwd-bottom'>
           <%= link_to profile_path do %>
             <% if current_user.profile_image&.avatar&.attached? %>
-              <%= image_tag(current_user.profile_image.avatar, class: 'my-0 mx-auto w-16 h-16 rounded-full') %>
+              <%= image_tag(current_user.profile_image.avatar, class: 'my-0 mx-auto w-16 h-16 rounded-full object-cover') %>
             <% else %>
-              <%= image_tag('sample.jpeg', class: 'my-0 mx-auto w-16 h-16 rounded-full') %>
+              <%= image_tag('sample.jpeg', class: 'my-0 mx-auto w-16 h-16 rounded-full object-cover') %>
             <% end %>
               <span><%= current_user.name %></span>
           <% end %> 

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -2,9 +2,9 @@
 <h2 class='text-main-orange font-bold pt-4 pb-5 mb-5 mx-auto text-left text-xl'><%= spot.store_name %></h2>
 <div>
   <% if spot.image.present? %>
-    <%= image_tag spot.image, class: 'w-100 h-50 rounded-lg' %>
+    <%= image_tag spot.image, class: 'w-100 h-50 mb:w-1/2 md:h-screen mx-auto rounded-lg object-cover' %>
   <% else %>
-    <%= image_tag('sample.jpeg', class: 'w-100 h-50 rounded-lg') %>
+    <%= image_tag('sample.jpeg', class: 'w-100 h-50 rounded-lg object-cover') %>
   <% end %>
 </div>
 <p class='pt-4 pb-5 mb-5 mx-auto'><%= spot.introduction %></p>

--- a/app/views/tops/top.html.erb
+++ b/app/views/tops/top.html.erb
@@ -1,7 +1,7 @@
 <main class='py-0 px-5 my-0 mx-auto max-w-screen-xl h-full z-10'>
   <%= render 'shared/search', q: @q, url: plans_path %>
   <h1 class='text-accent-blue font-bold pt-4 pb-5 mb-5 mx-auto text-center text-xl'><%= t('.sub_title1') %></h1>
-  <div class="mb-10 md:grid md:grid-cols-2 md:gap-4 lg:grid lg:grid-cols-3">
+  <div class="mb-10 md:grid md:grid-cols-2 md:gap-4">
     <% if @new_plans.present? %>
       <% @new_plans.each do |plan| %>
         <%= render 'plans/plan', plan: plan %>
@@ -11,7 +11,7 @@
     <% end %>
   </div>
   <h1 class='text-accent-blue font-bold pt-4 pb-5 mb-5 mx-auto text-center text-xl'><%= t('.sub_title2') %></h1>
-  <div class="mb-10 md:grid md:grid-cols-2 md:gap-4 lg:grid lg:grid-cols-3">
+  <div class="mb-10 md:grid md:grid-cols-2 md:gap-4">
     <% if @new_plans.present? %>
       <% @plans.each do |plan| %>
         <%= render 'plans/plan', plan: plan %>


### PR DESCRIPTION
### レイアウト修正
画像関係の投稿において、縦長画像を使用すると縦横の調整時に画像が歪んでしまう問題の修正。
object-fitプロパディを画像関係のCSSに追加した。
また、タブレットとPCで投稿詳細を開いた際の画像サイズの修正と一覧画面のカードの表示を横2枚に統一した。

### 投稿詳細に投稿者がわかるように修正
現在は投稿詳細に投稿者の情報がないので、投稿者の情報を表示するように修正した。