### PR TITLE
検索機能の修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
       grouping_hash = key_words.reduce({}) do |hash, word|
         hash.merge(word => { title_or_body_or_spots_store_name_or_spots_address_cont: word })
       end
-      @search_plans = Plan.ransack({ combinator: 'and', groupings: grouping_hash }).result.includes(:user).order(created_at: :desc)
+      @search_plans = Plan.ransack({ combinator: 'and', groupings: grouping_hash }).result(distinct: true).includes(:user).order(created_at: :desc)
     end
   end
 end


### PR DESCRIPTION
以下問題を解消
検索結果に同じplanが複数回表示される
原因としては、Planには紐づく複数のidが異なるspot情報があり、Plan内のspotで検索に該当した個数分一覧に表示されいる。
例えば、「大阪　ハイキング」と調べた際に、あるPlanの中にあるspot10個の内、5個該当すれば、検索結果にはPlanが5個表示されしまっている。

result(distinct: true)にすることで解消