### PR TITLE
位置情報機能のリリース

### DIFF
--- a/app/views/plans/spots_map.html.erb
+++ b/app/views/plans/spots_map.html.erb
@@ -39,8 +39,8 @@
           loadingModal.style.display = 'none';
         },
         () => {
-          handleLocationError(true, map.Center());
           loadingModal.style.display = 'none';
+          handleLocationError(true, map.Center());
         }
       );
     } else {
@@ -72,7 +72,7 @@
           marker.addListener('click', function() {
             const modalContent = `
             <div class='sm:mx-10 md:mx-20'>
-              <p class='mb-3 font-bold text-lg'><%= spot.store_name %></p>
+              <p class='mt-3 mb-3 font-bold text-lg'><%= spot.store_name %></p>
               <% if spot.image.present? %>
                 <%= image_tag spot.image, class: 'w-64 h-32 mb-3 rounded-lg object-cover' %>
               <% end %>

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -6,7 +6,7 @@
     </button>
   </div>
 <% end %>
-<div class='mt-3 mb-6 sm:mx-32' style='display: none;'>
+<div class='mt-3 mb-6 sm:mx-32'>
   <%= link_to spots_map_plans_path, class:'text-accent-blue text-xs md:text-sm font-bold hover:opacity-75' do %>
     <p>現在位置からおすすめスポットを探す →</p>
   <% end %>


### PR DESCRIPTION
## チケットへのリンク

http://localhost:3000/plans/spots_map

## やったこと(issue番号も記述する)

現在位置からおすすめスポットを探す機能のリリース

## やらないこと

なし

## できるようになること（ユーザ目線）

検索バー下にある「現在位置からおすすめスポットを探す →」をクリックすると現在位置を中心としたマップが表示され、現在位置周辺のおすすめスポットを調べることができる。
また、位置情報取得を拒否した場合は、デフォルトで東京を中心に表示される。

## できなくなること（ユーザ目線）

なし

## 動作確認

ブラウザ上で動作確認済み

## その他

コスト面が心配