### PR TITLE
投稿編集画面でおすすめスポットを削除する機能

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,0 +1,8 @@
+class SpotsController < ApplicationController
+  before_action :authenticate_user!
+
+  def destroy
+    @spot = Spot.find(params[:id])
+    @spot.destroy!
+  end
+end

--- a/app/views/plans/_edit_spot_fields.html.erb
+++ b/app/views/plans/_edit_spot_fields.html.erb
@@ -1,57 +1,64 @@
-<div class='pt-10 sm:mx-32'>
-  <%= f.label :store_name %>
-  <label class='input flex items-center gap-2 bg-white'>
-    <%= f.text_field :store_name, id: 'store', class:'w-full', placeholder: t('.store_name_placeholder') %>
-  </label>
-</div>
-
-<div class='pt-10 sm:mx-32'>
-  <%= f.label :introduction %>
-  <label class='flex'>
-  <%= f.text_area :introduction, class:'textarea h-24 w-full resize-none text-base bg-white', placeholder: t('.introduction_placeholder') %>
-  </label>
-</div>
-
-<div class='pt-10 sm:mx-32' style='display: none;'>
-  <%= f.label :address %>
-  <label class='input flex items-center gap-2 bg-white'>
-    <%= f.text_field :address, id: 'address' %>
-  </label>
-</div>
-
-<div class='pt-10 sm:mx-32' style='display: none;'>
-  <%= f.label :site_url %>
-  <label class='input  flex items-center gap-2 bg-white'>
-    <%= f.text_field :site_url, id: 'url' %>
-  </label>
-</div>
-
-<div class='pt-10 sm:mx-32' style='display: none;'>
-  <%= f.label :opening_hours %>
-  <label class='input  flex items-center gap-2 bg-white'>
-    <%= f.text_field :opening_hours, id: 'opening' %>
-  </label>
-</div>
-
-<div class='pt-10 sm:mx-32' style='display: none;'>
-  <%= f.label :phone_number %>
-  <label class='input  flex items-center gap-2 bg-white'>
-    <%= f.text_field :phone_number, id: 'phone' %>
-  </label>
-</div>
-
-<div class='pt-10 mb-5 sm:mx-32'>
-  <%= f.label :image %>
-  <div class='flex'>
-    <%= f.file_field :image, class: 'w-full, file-input border-none custom-file-input bg-white' %>
+<div id="delete-spot-<%= "#{f.object.id}" %>">
+  <div class='pt-10 sm:mx-32'>
+    <%= f.label :store_name %>
+    <label class='input flex items-center gap-2 bg-white'>
+      <%= f.text_field :store_name, id: 'store', class:'w-full', placeholder: t('.store_name_placeholder') %>
+    </label>
   </div>
-  <div class='sm:mx-32'>
-    <% if f.object.image&.attached? %>
-      <p><%= t('.current_image') %></p>
-      <div>
-        <%= image_tag f.object.image, class: 'w-32 h-32 rounded-lg object-cover' %>
-      </div>
-    <% end %>
+
+  <div class='pt-10 sm:mx-32'>
+    <%= f.label :introduction %>
+    <label class='flex'>
+    <%= f.text_area :introduction, class:'textarea h-24 w-full resize-none text-base bg-white', placeholder: t('.introduction_placeholder') %>
+    </label>
   </div>
+
+  <div class='pt-10 sm:mx-32' style='display: none;'>
+    <%= f.label :address %>
+    <label class='input flex items-center gap-2 bg-white'>
+      <%= f.text_field :address, id: 'address' %>
+    </label>
+  </div>
+
+  <div class='pt-10 sm:mx-32' style='display: none;'>
+    <%= f.label :site_url %>
+    <label class='input  flex items-center gap-2 bg-white'>
+      <%= f.text_field :site_url, id: 'url' %>
+    </label>
+  </div>
+
+  <div class='pt-10 sm:mx-32' style='display: none;'>
+    <%= f.label :opening_hours %>
+    <label class='input  flex items-center gap-2 bg-white'>
+      <%= f.text_field :opening_hours, id: 'opening' %>
+    </label>
+  </div>
+
+  <div class='pt-10 sm:mx-32' style='display: none;'>
+    <%= f.label :phone_number %>
+    <label class='input  flex items-center gap-2 bg-white'>
+      <%= f.text_field :phone_number, id: 'phone' %>
+    </label>
+  </div>
+
+  <div class='pt-10 mb-5 sm:mx-32'>
+    <%= f.label :image %>
+    <div class='flex'>
+      <%= f.file_field :image, class: 'w-full, file-input border-none custom-file-input bg-white' %>
+    </div>
+    <div class='sm:mx-32'>
+      <% if f.object.image&.attached? %>
+        <p><%= t('.current_image') %></p>
+        <div>
+          <%= image_tag f.object.image, class: 'w-32 h-32 rounded-lg object-cover' %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+  <%= link_to spot_path(f.object.id), data: { turbo_method: :delete, turbo_confirm: "#{ f.object.store_name }の情報を削除しますか？" } do %>
+    <div class='cursor-pointer pt-5 mb-5 sm:mx-32 text-right'>
+      <i class='fa-solid fa-trash-can fa-lg ml-5' style='color: #ed7b7b;'></i>
+    </div>
+  <% end %>
+  <div class='border-t border-gray-600 sm:mx-32 opacity-25 border-dotted'></div>
 </div>
-<div class='border-t border-gray-600 sm:mx-32 opacity-25 border-dotted'></div>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -2,9 +2,9 @@
 <h2 class='text-main-orange font-bold pt-4 pb-5 mb-5 mx-auto text-left text-xl'><%= spot.store_name %></h2>
 <div>
   <% if spot.image.present? %>
-    <%= image_tag spot.image, class: 'w-96 h-48 mb:w-1/2 md:h-screen mx-auto rounded-lg object-cover' %>
+    <%= image_tag spot.image, class: 'w-100 h-50 mb:w-1/2 md:h-screen mx-auto rounded-lg object-cover' %>
   <% else %>
-    <%= image_tag('sample.jpeg', class: 'w-96 h-48 mx-auto rounded-lg object-cover') %>
+    <%= image_tag('sample.jpeg', class: 'w-100 h-50 mx-auto rounded-lg object-cover') %>
   <% end %>
 </div>
 <p class='pt-4 pb-5 mb-5 mx-auto break-words'><%= auto_link_urls(spot.introduction) %></p>

--- a/app/views/spots/destroy.turbo_stream.erb
+++ b/app/views/spots/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove "delete-spot-#{@spot.id}" %>

--- a/app/views/static_pages/usage.html.erb
+++ b/app/views/static_pages/usage.html.erb
@@ -2,7 +2,7 @@
 <main class='py-0 px-5 my-0 mx-auto max-w-screen-xl h-full z-10'>
   <h1 class='text-accent-blue font-bold pt-4 pb-5 mb-5 mx-auto text-center text-xl'><%= t('.title') %></h1>
   <div class="mb-10">
-    <%= image_tag('tabitsunagi.png', class: 'w-96 h-48 mx-auto rounded-lg object-cover') %>
+    <%= image_tag('tabitsunagi.png', class: 'w-96 h-56 mx-auto rounded-lg object-cover') %>
     <p class='md:text-center'>"旅つなぎ"は自分のおすすめ旅行スポットを簡単に共有し合えるサービスです。</p>
     <div class='pt-10 mb-10 text-center'>
       <% if user_signed_in? %>
@@ -16,7 +16,7 @@
       <ul class='list-inside list-disc'>
         <li class='mt-5 mb-1'>おすすめ旅スポットを投稿する</li>
         <p class='pl-5 mb-3'>おすすめの旅スポットを投稿することができます。一つの投稿で複数の旅スポットを投稿することもできます。<br><span class='text-custom-red'>※投稿はログインユーザー限定のサービスです。</span></p>
-        <%= image_tag('post.png', class: 'w-96 h-48 mx-auto rounded-lg object-cover') %>
+        <%= image_tag('post.png', class: 'w-96 h-56 mx-auto rounded-lg object-cover') %>
         <div class='pt-10 mb-10 text-center'>
           <% if user_signed_in? %>
             <%= link_to t('.post'), new_plan_path, class: 'btn bg-accent-blue text-white px-5 w-64 hover:bg-accent-blue hover:opacity-50' %>
@@ -31,9 +31,9 @@
       <ul class='list-inside list-disc'>
         <li class='mt-5 mb-1'>みんなの投稿を見る</li>
         <p class='pl-5 mb-3'>みんなの投稿した旅スポットを見ることができます。<br>おすすめポイントや施設のホームページにもアクセスできます！</p>
-        <%= image_tag('spot.png', class: 'w-96 h-48 mx-auto rounded-lg object-cover mb-3') %>
+        <%= image_tag('spot.png', class: 'w-96 h-56 mx-auto rounded-lg object-cover mb-3') %>
         <p class='pl-5 mb-3'>現在地周辺のおすすめスポットを地図上で探すことができます！<br><span class='text-custom-red'>※ログインユーザー限定のサービスです。</span></p>
-        <%= image_tag('map.png', class: 'w-96 h-48 mx-auto rounded-lg object-cover') %>
+        <%= image_tag('map.png', class: 'w-96 h-56 mx-auto rounded-lg object-cover') %>
         <div class='pt-10 mb-10 text-center'>
           <%= link_to t('.List_of_posts'), plans_path, class: 'btn bg-main-orange text-white px-5 w-64 hover:bg-main-orange hover:opacity-50' %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :spots, only: [:destroy]
+
   resource :profile, only: %i[edit show update destroy] do
     member do
       get :email_edit


### PR DESCRIPTION
## チケットへのリンク

http://localhost:3000/plans/45/edit

## やったこと(issue番号も記述する)

- [x] #121 

## やらないこと

なし

## できるようになること（ユーザ目線）

投稿編集画面でDBに登録済みのSpotレコードを削除することができるようになった。

## できなくなること（ユーザ目線）

なし

## 動作確認

ブラウザ上で動作確認済み

## その他

なし