### PR TITLE
スポットフォームのアコーディオン化

### DIFF
--- a/app/views/plans/_add_edit_spot_fields.html.erb
+++ b/app/views/plans/_add_edit_spot_fields.html.erb
@@ -14,37 +14,44 @@
     </label>
   </div>
 
-  <div class='pt-10 sm:mx-32' style='display: none;'>
-    <%= f.label :address %>
-    <label class='input flex items-center gap-2 bg-white'>
-      <%= f.text_field :address, id: 'address' %>
-    </label>
-  </div>
-
-  <div class='pt-10 sm:mx-32' style='display: none;'>
-    <%= f.label :site_url %>
-    <label class='input  flex items-center gap-2 bg-white'>
-      <%= f.text_field :site_url, id: 'url' %>
-    </label>
-  </div>
-
-  <div class='pt-10 sm:mx-32' style='display: none;'>
-    <%= f.label :opening_hours %>
-    <label class='input  flex items-center gap-2 bg-white'>
-      <%= f.text_field :opening_hours, id: 'opening' %>
-    </label>
-  </div>
-
-  <div class='pt-10 sm:mx-32' style='display: none;'>
-    <%= f.label :phone_number %>
-    <label class='input  flex items-center gap-2 bg-white'>
-      <%= f.text_field :phone_number, id: 'phone' %>
-    </label>
+  <div class='pt-10 sm:mx-32'>
+    <%= f.label :image %>
+    <%= f.file_field :image, class: 'w-full, file-input border-none custom-file-input bg-white' %>
   </div>
 
   <div class='pt-10 mb-5 sm:mx-32'>
-    <%= f.label :image %>
-    <%= f.file_field :image, class: 'w-full, file-input border-none custom-file-input bg-white' %>
+    <details class="collapse bg-base-200">
+      <summary class="collapse-title font-medium">その他の情報を見る</summary>
+      <div class="collapse-content">
+        <div class='pt-10'>
+          <%= f.label :address %>
+          <label class='input flex items-center gap-2 bg-white'>
+            <%= f.text_field :address, id: 'address', class:'w-full' %>
+          </label>
+        </div>
+
+        <div class='pt-10'>
+          <%= f.label :site_url %>
+          <label class='input flex items-center gap-2 bg-white'>
+            <%= f.text_field :site_url, id: 'url', class:'w-full' %>
+          </label>
+        </div>
+
+        <div class='pt-10'>
+          <%= f.label :opening_hours %>
+          <label class='input flex items-center gap-2 bg-white'>
+            <%= f.text_field :opening_hours, id: 'opening', class:'w-full' %>
+          </label>
+        </div>
+
+        <div class='pt-10'>
+          <%= f.label :phone_number %>
+          <label class='input flex items-center gap-2 bg-white'>
+            <%= f.text_field :phone_number, id: 'phone', class:'w-full' %>
+          </label>
+        </div>
+      </div>
+    </details>
   </div>
 
   <div class='cursor-pointer remove-spot pt-5 sm:mx-32 text-right'>

--- a/app/views/plans/_edit_spot_fields.html.erb
+++ b/app/views/plans/_edit_spot_fields.html.erb
@@ -13,35 +13,7 @@
     </label>
   </div>
 
-  <div class='pt-10 sm:mx-32' style='display: none;'>
-    <%= f.label :address %>
-    <label class='input flex items-center gap-2 bg-white'>
-      <%= f.text_field :address, id: 'address' %>
-    </label>
-  </div>
-
-  <div class='pt-10 sm:mx-32' style='display: none;'>
-    <%= f.label :site_url %>
-    <label class='input  flex items-center gap-2 bg-white'>
-      <%= f.text_field :site_url, id: 'url' %>
-    </label>
-  </div>
-
-  <div class='pt-10 sm:mx-32' style='display: none;'>
-    <%= f.label :opening_hours %>
-    <label class='input  flex items-center gap-2 bg-white'>
-      <%= f.text_field :opening_hours, id: 'opening' %>
-    </label>
-  </div>
-
-  <div class='pt-10 sm:mx-32' style='display: none;'>
-    <%= f.label :phone_number %>
-    <label class='input  flex items-center gap-2 bg-white'>
-      <%= f.text_field :phone_number, id: 'phone' %>
-    </label>
-  </div>
-
-  <div class='pt-10 mb-5 sm:mx-32'>
+  <div class='pt-10 sm:mx-32'>
     <%= f.label :image %>
     <div class='flex'>
       <%= f.file_field :image, class: 'w-full, file-input border-none custom-file-input bg-white' %>
@@ -55,6 +27,42 @@
       <% end %>
     </div>
   </div>
+
+    <div class='pt-10  mb-5 sm:mx-32'>
+    <details class="collapse bg-base-200">
+      <summary class="collapse-title font-medium">その他の情報を見る</summary>
+      <div class="collapse-content">
+        <div class='pt-10'>
+          <%= f.label :address %>
+          <label class='input flex items-center gap-2 bg-white'>
+            <%= f.text_field :address, id: 'address', class:'w-full' %>
+          </label>
+        </div>
+
+        <div class='pt-10'>
+          <%= f.label :site_url %>
+          <label class='input flex items-center gap-2 bg-white'>
+            <%= f.text_field :site_url, id: 'url', class:'w-full' %>
+          </label>
+        </div>
+
+        <div class='pt-10'>
+          <%= f.label :opening_hours %>
+          <label class='input flex items-center gap-2 bg-white'>
+            <%= f.text_field :opening_hours, id: 'opening', class:'w-full' %>
+          </label>
+        </div>
+
+        <div class='pt-10'>
+          <%= f.label :phone_number %>
+          <label class='input flex items-center gap-2 bg-white'>
+            <%= f.text_field :phone_number, id: 'phone', class:'w-full' %>
+          </label>
+        </div>
+      </div>
+    </details>
+  </div>
+
   <%= link_to spot_path(f.object.id), data: { turbo_method: :delete, turbo_confirm: "#{ f.object.store_name }の情報を削除しますか？" } do %>
     <div class='cursor-pointer pt-5 mb-5 sm:mx-32 text-right'>
       <i class='fa-solid fa-trash-can fa-lg ml-5' style='color: #ed7b7b;'></i>

--- a/app/views/plans/_spot_fields.html.erb
+++ b/app/views/plans/_spot_fields.html.erb
@@ -14,33 +14,41 @@
     </label>
   </div>
 
-  <div class='pt-10 sm:mx-32' style='display: none;'>
-    <%= f.label :address %>
-    <label class='input flex items-center gap-2 bg-white'>
-      <%= f.text_field :address, id: 'address' %>
-    </label>
+  <div class='pt-10 sm:mx-32'>
+    <details class="collapse bg-base-200">
+      <summary class="collapse-title font-medium">その他の情報を見る</summary>
+      <div class="collapse-content">
+        <div class='pt-10'>
+          <%= f.label :address %>
+          <label class='input flex items-center gap-2 bg-white'>
+            <%= f.text_field :address, id: 'address', class:'w-full' %>
+          </label>
+        </div>
+
+        <div class='pt-10'>
+          <%= f.label :site_url %>
+          <label class='input flex items-center gap-2 bg-white'>
+            <%= f.text_field :site_url, id: 'url', class:'w-full' %>
+          </label>
+        </div>
+
+        <div class='pt-10'>
+          <%= f.label :opening_hours %>
+          <label class='input flex items-center gap-2 bg-white'>
+            <%= f.text_field :opening_hours, id: 'opening', class:'w-full' %>
+          </label>
+        </div>
+
+        <div class='pt-10'>
+          <%= f.label :phone_number %>
+          <label class='input flex items-center gap-2 bg-white'>
+            <%= f.text_field :phone_number, id: 'phone', class:'w-full' %>
+          </label>
+        </div>
+      </div>
+    </details>
   </div>
 
-  <div class='pt-10 sm:mx-32' style='display: none;'>
-    <%= f.label :site_url %>
-    <label class='input  flex items-center gap-2 bg-white'>
-      <%= f.text_field :site_url, id: 'url' %>
-    </label>
-  </div>
-
-  <div class='pt-10 sm:mx-32' style='display: none;'>
-    <%= f.label :opening_hours %>
-    <label class='input  flex items-center gap-2 bg-white'>
-      <%= f.text_field :opening_hours, id: 'opening' %>
-    </label>
-  </div>
-
-  <div class='pt-10 sm:mx-32' style='display: none;'>
-    <%= f.label :phone_number %>
-    <label class='input  flex items-center gap-2 bg-white'>
-      <%= f.text_field :phone_number, id: 'phone' %>
-    </label>
-  </div>
   <div class='cursor-pointer remove-spot pt-5 sm:mx-32 text-right'>
     <i class='fa-solid fa-trash-can fa-lg ml-5' style='color: #ed7b7b;'></i>
   </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -13,5 +13,7 @@ ja:
         address: 住所(任意)
         site_url: サイトURL(任意)
         image: 画像(任意)
+        opening_hours: 営業時間(任意)
+        phone_number: 電話番号(任意)
       profile_image:
         avatar: プロフィール画像


### PR DESCRIPTION
## チケットへのリンク

http://localhost:3000/plans/new
http://localhost:3000/plans/:id/edit

## やったこと(issue番号も記述する)

- [ ] #127 

## やらないこと

なし

## できるようになること（ユーザ目線）

新規投稿、編集時におすすめスポットの入力フォームのうち、住所・サイトURL・営業時間・電話番号がアコーディオンメニューで開閉できるようになった。

## できなくなること（ユーザ目線）

なし

## 動作確認

ブラウザ上で動作確認済み

## その他

なし